### PR TITLE
Correct Bad Int to Long Conversion

### DIFF
--- a/src/codeu/chat/common/Time.java
+++ b/src/codeu/chat/common/Time.java
@@ -30,18 +30,14 @@ public final class Time implements Comparable<Time> {
     @Override
     public void write(OutputStream out, Time value) throws IOException {
 
-      Serializers.INTEGER.write(out, (int)(0xFFFFFFFF & (value.totalMs >>> 32)));
-      Serializers.INTEGER.write(out, (int)(0xFFFFFFFF & (value.totalMs >>> 0)));
+      Serializers.LONG.write(out, value.totalMs);
 
     }
 
     @Override
     public Time read(InputStream in) throws IOException {
 
-      final long high = (long)Serializers.INTEGER.read(in);
-      final long low = (long)Serializers.INTEGER.read(in);
-
-      return Time.fromMs((high << 32) | low);
+      return Time.fromMs(Serializers.LONG.read(in));
 
     }
   };

--- a/src/codeu/chat/util/Serializers.java
+++ b/src/codeu/chat/util/Serializers.java
@@ -40,10 +40,9 @@ public final class Serializers {
     @Override
     public void write(OutputStream out, Integer value) throws IOException {
 
-      out.write(0xFF & (value >> 24));
-      out.write(0xFF & (value >> 16));
-      out.write(0xFF & (value >> 8));
-      out.write(0xFF & (value >> 0));
+      for (int i = 24; i >= 0; i -= 8) {
+        out.write(0xFF & (value >>> i));
+      }
 
     }
 
@@ -52,10 +51,34 @@ public final class Serializers {
 
       int value = 0;
 
-      value = (value << 8) | in.read();
-      value = (value << 8) | in.read();
-      value = (value << 8) | in.read();
-      value = (value << 8) | in.read();
+      for (int i = 0; i < 4; i++) {
+        value = (value << 8) | in.read();
+      }
+
+      return value;
+
+    }
+  };
+
+  public static final Serializer<Long> LONG = new Serializer<Long>() {
+
+    @Override
+    public void write(OutputStream out, Long value) throws IOException {
+
+      for (int i = 56; i >= 0; i -= 8) {
+        out.write((int)(0xFF & (value >>> i)));
+      }
+
+    }
+
+    @Override
+    public Long read(InputStream in) throws IOException {
+
+      long value = 0;
+
+      for (int i = 0; i < 8; i++) {
+        value = (value << 8) | in.read();
+      }
 
       return value;
 


### PR DESCRIPTION
In the serializer for Time, there was a problem with
the low bits where the source integer was negative
leading to the long being negative.

The change adds a serializer for longs that should
help protect bad custom long serialization.